### PR TITLE
Update cookielaw_tags.py

### DIFF
--- a/cookielaw/templatetags/cookielaw_tags.py
+++ b/cookielaw/templatetags/cookielaw_tags.py
@@ -18,6 +18,6 @@ class CookielawBanner(InclusionTag):
         if context['request'].COOKIES.get('cookielaw_accepted', False):
             return ''
         data = self.get_context(context, **kwargs)
-        return render_to_string(template, data)
+        return render_to_string(template, data, context_instance=context)
 
 register.tag(CookielawBanner)


### PR DESCRIPTION
Added context_instance to be passed into the render_to_string. If you do not pass the context, you are not able to render django template tags in the template. For instance I was unable to render Django CMS page_url template tag, but adding context solved the problem.

I ran the tests, and one of the tests was failing before and after the change.