### PR TITLE
Warn on missing request context instead of raising KeyError

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,8 @@ stylesheet.
 Changelog
 =========
 
+* **1.0.6** `django.core.context_processors.request` is still required but if not available in template context a
+            warning will be raise instead of a `KeyError`
 * **1.0.5** added Dutch translation thanks to douwevandermeij_
 * **1.0.4** context_instance is now passed to the banner template
 * **1.0.3** added Italian translation thanks to Jiloc_

--- a/cookielaw/__init__.py
+++ b/cookielaw/__init__.py
@@ -1,1 +1,1 @@
-VERSION = (1, 0, 5)
+VERSION = (1, 0, 6)

--- a/cookielaw/templatetags/cookielaw_tags.py
+++ b/cookielaw/templatetags/cookielaw_tags.py
@@ -1,3 +1,5 @@
+import warnings
+
 from classytags.helpers import InclusionTag
 from django import template
 from django.template.loader import render_to_string
@@ -15,8 +17,14 @@ class CookielawBanner(InclusionTag):
 
     def render_tag(self, context, **kwargs):
         template_filename = self.get_template(context, **kwargs)
+
+        if 'request' not in context:
+            warnings.warn('No request object in context. '
+                          'Are you sure you have django.core.context_processors.request enabled?')
+
         if context['request'].COOKIES.get('cookielaw_accepted', False):
             return ''
+
         data = self.get_context(context, **kwargs)
         return render_to_string(template_filename, data, context_instance=context)
 


### PR DESCRIPTION
This should fix #9 