### PR TITLE
Avoid RemovedInDjango110Warning

### DIFF
--- a/cookielaw/templatetags/cookielaw_tags.py
+++ b/cookielaw/templatetags/cookielaw_tags.py
@@ -28,7 +28,7 @@ class CookielawBanner(InclusionTag):
 
         data = self.get_context(context, **kwargs)
 
-        if django.VERSION[:2] < (1, 10):
+        if django.VERSION[:2] < (1, 8):
             return render_to_string(template_filename, data, context_instance=context)
         else:
             return render_to_string(template_filename, data, context.request)


### PR DESCRIPTION
The context argument used to be called dictionary. That name is deprecated in Django 1.8 and will be removed in Django 1.10.
https://docs.djangoproject.com/en/1.8/topics/http/shortcuts/#id2