### PR TITLE
Add tests for Django 2.0 to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,28 +11,27 @@ env:
   global:
     - DJANGO_SETTINGS_MODULE=settings
   matrix:
-    - DJANGO="Django<1.9"
     - DJANGO="Django<1.10"
     - DJANGO="Django<1.11"
     - DJANGO="Django<1.12"
+    - DJANGO="Django<2.1"
 matrix:
   exclude:
     # See: https://docs.djangoproject.com/en/1.11/faq/install/#what-python-version-can-i-use-with-django
+    - python: "2.7"
+      env: DJANGO="Django<2.1"
     - python: "3.3"
       env: DJANGO="Django<1.10"
     - python: "3.3"
       env: DJANGO="Django<1.11"
     - python: "3.3"
       env: DJANGO="Django<1.12"
-    - python: "3.6"
-      env: DJANGO="Django<1.9"
+    - python: "3.3"
+      env: DJANGO="Django<2.1"
     - python: "3.6"
       env: DJANGO="Django<1.10"
     - python: "3.6"
       env: DJANGO="Django<1.11"
-  allow_failures:
-    - python: "3.3"
-      env: DJANGO="Django<1.9"
 cache:
   directories:
     - $HOME/.cache/pip


### PR DESCRIPTION
Also, since 1.8 is no longer supported, remove it from tests.