### PR TITLE
package name was wrong in docs and in exception message

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Installation
 #. Run ``collectstatic`` (Django 1.3+) or copy the statics to your media directory
 #. Add ``cookielaw/js/cookielaw.js`` to the markup directly or via your asset
    manager such as ``django-pipeline`` or ``django-compressor``
-#. If you're using Django > 1.8, enable ``'django.core.context_processors.request'`` in your ``TEMPLATES['OPTIONS']`` setting, eg.:
+#. If you're using Django > 1.8, enable ``'django.template.context_processors.request'`` in your ``TEMPLATES['OPTIONS']`` setting, eg.:
 
     ::
 

--- a/cookielaw/templatetags/cookielaw_tags.py
+++ b/cookielaw/templatetags/cookielaw_tags.py
@@ -21,7 +21,7 @@ class CookielawBanner(InclusionTag):
 
         if 'request' not in context:
             warnings.warn('No request object in context. '
-                          'Are you sure you have django.core.context_processors.request enabled?')
+                          'Are you sure you have django.template.context_processors.request enabled?')
 
         if context['request'].COOKIES.get('cookielaw_accepted', False):
             return ''


### PR DESCRIPTION
It's django.**template**.context_processors.request -- not ...**core**...

this was correct in the context_processors-list in the readme, but wrong in the line above. Also, it was wrong in the the error-message thrown by the templatetag.