### PR TITLE
Fix new-style use of render_to_string

### DIFF
--- a/cookielaw/templatetags/cookielaw_tags.py
+++ b/cookielaw/templatetags/cookielaw_tags.py
@@ -28,7 +28,8 @@ class CookielawBanner(InclusionTag):
 
         data = self.get_context(context, **kwargs)
 
-        if django.VERSION[:2] < (1, 10):
+        # Author made this 8 but since didn't pass guessing 9 might work better?
+        if django.VERSION[:2] < (1, 8):
             return render_to_string(template_filename, data, context_instance=context)
         else:
             return render_to_string(template_filename, data, context.request)


### PR DESCRIPTION
- Combines:
https://github.com/TyMaszWeb/django-cookie-law/pull/32/commits/588892c18cbf885b67c8c2ebd53c565f6bad5b7c

- With naming the 3rd argument so it's not intepreted as the old context