### PR TITLE
Better handling of missing context 'request' attribute

### DIFF
--- a/cookielaw/templatetags/cookielaw_tags.py
+++ b/cookielaw/templatetags/cookielaw_tags.py
@@ -24,7 +24,7 @@ class CookielawBanner(InclusionTag):
                           'Are you sure you have django.core.context_processors.request enabled?')
             return ''
 
-        if context['request'].COOKIES.get('cookielaw_accepted', False):
+        elif context['request'].COOKIES.get('cookielaw_accepted', False):
             return ''
 
         data = self.get_context(context, **kwargs)
@@ -32,6 +32,6 @@ class CookielawBanner(InclusionTag):
         if django.VERSION[:2] < (1, 10):
             return render_to_string(template_filename, data, context_instance=context)
         else:
-            return render_to_string(template_filename, data, context.request)
+            return render_to_string(template_filename, data, getattr(context, 'request', None))
 
 register.tag(CookielawBanner)


### PR DESCRIPTION
As noted in https://github.com/TyMaszWeb/django-cookie-law/issues/9#issuecomment-127992714, the check for `context.request` falls though and hence a KeyError is still thrown. This PR contains a fix which stops the falling though that wasn't merged previously, which will fix #9 (which is incorrectly closed).