### PR TITLE
Remove pytest-runner dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     install_requires=[
         'Django>=1.8',
         'django-classy-tags>=0.3.0',
-        'pytest-runner>=2.11.1'
     ],
     tests_require=[
         'six',


### PR DESCRIPTION
As noted on https://github.com/pytest-dev/pytest-runner#deprecation-notice,
pytest-runner is deprecated:

    pytest-runner depends on deprecated features of setuptools and relies on
    features that break security mechanisms in pip. For example
    'setup_requires' and 'tests_require' bypass pip --require-hashes.
    See also pypa/setuptools#1684.

    It is recommended that you:

    - Remove 'pytest-runner' from your setup_requires, preferably removing the setup_requires option.
    - Remove 'pytest' and any other testing requirements from tests_require, preferably removing the tests_requires option.
    - Select a tool to bootstrap and then run tests such as tox.